### PR TITLE
Update 2_kb_to_vectordb_opensearch.ipynb

### DIFF
--- a/blogs/opensearch-data-ingestion/2_kb_to_vectordb_opensearch.ipynb
+++ b/blogs/opensearch-data-ingestion/2_kb_to_vectordb_opensearch.ipynb
@@ -264,7 +264,7 @@
    "outputs": [],
    "source": [
     "# if used a different name while creating the cloud formation stack then change this to match the name you used\n",
-    "CFN_STACK_NAME = \"rag22\""
+    "CFN_STACK_NAME = \"llm-apps-blog-rag\""
    ]
   },
   {
@@ -4791,7 +4791,7 @@
    "id": "087307b9-ab77-4956-9308-7856b515583e",
    "metadata": {},
    "source": [
-    "## Step 4: Do a similarity search for for user input to documents (embeddings) in OpenSearch"
+    "## Step 4: Do a similarity search for user input to documents (embeddings) in OpenSearch"
    ]
   },
   {


### PR DESCRIPTION
The default CloudFormation stack name is actually "llm-apps-blog-rag" . Struggle to figure this out for about 2 hours. So making the changes to make it easier for others

*Issue #, if available:* 
The default CloudFormation stack name is actually llm-apps-blog-rag . Struggle to figure this out for about 2 hours. So making the changes to make it easier for others

*Description of changes:*
Changed the CloudFormation template name is the notebook "2_kb_to_vectordb_opensearch" from "rag22" to "llm-apps-blog-rag"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
